### PR TITLE
Fix issue retaining the FBTweak value between app launches

### DIFF
--- a/Barricade/Tweaks/MMBarricadeTweaksResponseStore.m
+++ b/Barricade/Tweaks/MMBarricadeTweaksResponseStore.m
@@ -116,7 +116,6 @@ FBTweak *mm_FBArrayTweak(NSString *categoryName, NSString *collectionName, NSStr
         tweak = [[FBTweak alloc] initWithIdentifier:tweakName];
         tweak.name = tweakName;
         tweak.possibleValues = array;
-        tweak.currentValue = nil;
         tweak.defaultValue = defaultValue;
         [collection addTweak:tweak];
     }


### PR DESCRIPTION
Everytime the app starts the fbvalue is reset to the defaul value.

Cause: Creating a new instance of FBTweak and setting the current value to nil resets the UserDefaults value. FBTweak gets instantiated with an identifier which is therefore used as a key to get the value for UserDefaulst store so there is no need to set the current value to nil when instantiating a new FBTweak